### PR TITLE
Parenthesize graphIO ternary condition

### DIFF
--- a/planarity/c/graphLib/io/graphIO.c
+++ b/planarity/c/graphLib/io/graphIO.c
@@ -351,7 +351,7 @@ int _ReadLEDAGraph(graphP theGraph, strOrFileP inputContainer)
 
     int graphType = 0;
     int N = 0, M = 0, u = NIL, v = NIL;
-    int zeroBasedOffset = gp_LowerBoundVertexStorage(theGraph) == 0 ? 1 : 0;
+    int zeroBasedOffset = gp_LowerBoundVertexStorage(theGraph) == ( 0 ) ? ( 1 ) : 0;
     char Line[MAXLINE + 1];
 
     memset(Line, '\0', (MAXLINE + 1));


### PR DESCRIPTION
## Summary
- add explicit grouping around the zero-based storage check used by the LEDA reader in the planarity package copy of `graphIO.c`
- keep the change limited to the warning-remediation expression described in #62
- leave the canonical EAPS `graphIO.c` counterpart for a follow-up because that file is currently part of graph-algorithms/edge-addition-planarity-suite#275

Refs #62.

## Tests
- `git diff --check`
- `gcc -std=c99 -Wall -Wextra -Wparentheses -Werror -Wno-unused-parameter -I planarity/c/graphLib -I planarity/c/graphLib/lowLevelUtils -I planarity/c/graphLib/io -I planarity/c/graphLib/extensionSystem -I planarity/c/graphLib/planarityRelated -I planarity/c/graphLib/homeomorphSearch -c planarity/c/graphLib/io/graphIO.c -o %TEMP%\planarity-graphio-62\graphIO.o`
- `python setup.py sdist --dist-dir %TEMP%\planarity-sdist-62`

Not run locally: wheel build / pytest, because this Windows shell does not have MSVC Build Tools available. `python -m build --sdist --wheel` reached `bdist_wheel` and then stopped with `Microsoft Visual C++ 14.0 or greater is required`.